### PR TITLE
Fix divide by zero when image is smaller that supergrid

### DIFF
--- a/include/itkSLICImageFilter.hxx
+++ b/include/itkSLICImageFilter.hxx
@@ -180,7 +180,15 @@ SLICImageFilter<TInputImage, TOutputImage, TDistancePixel>
     totalErr[i] = size[i]%m_SuperGridSize[i];
 
     // the starting superpixel index
-    startIdx[i] = region.GetIndex()[i]+m_SuperGridSize[i]/2 + totalErr[i]/(strips[i]*2);
+    if (strips[i] != 0)
+      {
+      startIdx[i] = region.GetIndex()[i]+m_SuperGridSize[i]/2 + totalErr[i]/(strips[i]*2);
+      }
+    else
+      {
+      strips[i] = 1;
+      startIdx[i] = region.GetIndex()[i]+ totalErr[i]/2;
+      }
     idx[i] = startIdx[i];
 
     // with integer math keep track of the remaining odd pixel.

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -7,6 +7,7 @@ set(${itk-module}Tests
   itkObjectnessMeasureImageFilterTest.cxx
   itkHessianImageFilterTest.cxx
   itkSLICImageFilterTest.cxx
+  itkSLICImageFilterTest2.cxx
 )
 
 
@@ -42,7 +43,7 @@ itk_add_test(NAME itkObjectnessMeasureImageFilterTest2
 add_test(NAME itkHessianImageFilterTest
       COMMAND ${itk-module}TestDriver itkHessianImageFilterTest )
 
-itk_add_test(NAME itkSLICImageFilterTest1
+itk_add_test(NAME itkSLICImageFilterTest_1
   COMMAND ${itk-module}TestDriver
    --with-threads 1
    --compare  DATA{Baseline/itkSLICImageFilterTest1Baseline.nii}
@@ -51,7 +52,7 @@ itk_add_test(NAME itkSLICImageFilterTest1
    DATA{Input/VM1111Shrink-LAB.mha}
    ${TEMP}/itkSLICImageFilterTest1Output.nii 25 )
 
-itk_add_test(NAME itkSLICImageFilterTest2
+itk_add_test(NAME itkSLICImageFilterTest_2
   COMMAND ${itk-module}TestDriver
    --with-threads 80
    --compare  DATA{Baseline/itkSLICImageFilterTest1Baseline.nii}
@@ -60,13 +61,18 @@ itk_add_test(NAME itkSLICImageFilterTest2
    DATA{Input/VM1111Shrink-LAB.mha}
    ${TEMP}/itkSLICImageFilterTest2Output.nii 25 )
 
-itk_add_test(NAME itkSLICImageFilterTest3
+itk_add_test(NAME itkSLICImageFilterTest_3
   COMMAND ${itk-module}TestDriver
     --compare  DATA{Baseline/itkSLICImageFilterTest3Baseline.nii}
               ${TEMP}/itkSLICImageFilterTest3Output.nii
    itkSLICImageFilterTest
    DATA{Input/cthead1.png}
    ${TEMP}/itkSLICImageFilterTest3Output.nii 20 )
+
+
+itk_add_test(NAME itkSLICImageFilterTest2
+  COMMAND ${itk-module}TestDriver
+   itkSLICImageFilterTest2 )
 
 #
 # GTest based tests

--- a/test/itkSLICImageFilterTest2.cxx
+++ b/test/itkSLICImageFilterTest2.cxx
@@ -1,0 +1,71 @@
+/*=========================================================================
+ *
+ *  Copyright Insight Software Consortium
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
+#include "itkSLICImageFilter.h"
+#include "itkVectorImage.h"
+#include "itkRandomImageSource.h"
+
+
+namespace
+{
+}
+
+int itkSLICImageFilterTest2(int, char *[])
+{
+  const unsigned int gridSize = 50;
+  const float proximityWeight = 10.0;
+
+  const unsigned int VDimension = 2;
+  typedef itk::VectorImage<float, VDimension>  InputImageType;
+  typedef itk::Image<unsigned int, VDimension> OutputImageType;
+
+  InputImageType::Pointer input = InputImageType::New();
+
+  InputImageType::RegionType region;
+  InputImageType::SizeType size = {{gridSize+1, gridSize+1}};
+  region.SetSize( size );
+  input->SetRegions(region);
+  input->SetVectorLength(3);
+  input->Allocate();
+
+  typedef itk::SLICImageFilter< InputImageType, OutputImageType > FilterType;
+  FilterType::Pointer filter = FilterType::New();
+  filter->SetSpatialProximityWeight(proximityWeight);
+  filter->SetInput(input);
+
+
+  // check case where grid size is bigger than image
+  filter->SetSuperGridSize(gridSize);
+  filter->Update();
+
+  // check case where more threads than slices
+  input->Modified();
+  filter->SetNumberOfThreads(125);
+  filter->Update();
+
+  // check 1x1 image
+  InputImageType::SizeType size2 = {{1,1}};
+  region.SetSize( size2 );
+  input->SetRegions(region);
+  input->Allocate();
+  filter->Update();
+
+  filter->GetOutput()->Print(std::cout);
+
+  return 0;
+}


### PR DESCRIPTION
If the a dimension of the image was less that the super grid cluster
size than there was a integer divide by zero causing a segmentation
fault. This case is now correctly handled and test have been added for
this case.
